### PR TITLE
remove omniauth deletion off

### DIFF
--- a/app/models/devise_token_auth/concerns/user.rb
+++ b/app/models/devise_token_auth/concerns/user.rb
@@ -19,8 +19,6 @@ module DeviseTokenAuth::Concerns::User
     unless self.method_defined?(:devise_modules)
       devise :database_authenticatable, :registerable,
           :recoverable, :trackable, :validatable, :confirmable
-    else
-      self.devise_modules.delete(:omniauthable)
     end
 
     unless tokens_has_json_column_type?


### PR DESCRIPTION
on the read me of devise_token_auth, we need to put 'include DeviseTokenAuth::Concerns::User' after devise setting. This project is not requiring 'confirmable' module, and if we put 'include DeviseTokenAuth::Concerns::User' before devise setting, it will use devise_token_auth's devise setting which contains confirmable module.